### PR TITLE
Align worklets version with Expo Go

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
-        "react-native-worklets": "^0.7.1"
+        "react-native-worklets": "0.5.1"
       },
       "devDependencies": {
         "@babel/core": "^7.24.4",
@@ -6843,8 +6843,8 @@
       }
     },
     "node_modules/react-native-worklets": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.7.1.tgz",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.5.1.tgz",
       "integrity": "sha512-KNsvR48ULg73QhTlmwPbdJLPsWcyBotrGPsrDRDswb5FYpQaJEThUKc2ncXE4UM5dn/ewLoQHjSjLaKUVPxPhA==",
       "license": "MIT",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
-    "react-native-worklets": "^0.7.1"
+    "react-native-worklets": "0.5.1"
   },
   "devDependencies": {
     "@babel/core": "^7.24.4",


### PR DESCRIPTION
## Summary
- set react-native-worklets dependency to 0.5.1 to match Expo Go's native runtime version and prevent JS/native mismatch errors
- update lockfile to reflect the aligned worklets version

## Testing
- not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958f15249e083258e45dc7ab186dffd)